### PR TITLE
chore: sync pom.xml version to 0.1.0 post-release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>fr.marstech</groupId>
     <artifactId>mt-link-spray</artifactId>
-    <version>0.0.5</version>
+    <version>0.1.0</version>
     <name>mt-link-spray</name>
     <description>MarsTech Link Spray project</description>
     <url>https://github.com/alkaphreak/marstech-link-spray</url>


### PR DESCRIPTION
Post-release sync: the v0.1.0 release tag was created successfully but the back-merge to main failed due to branch protection rules. This PR updates pom.xml from 0.0.5 to 0.1.0 to align main with the released version.