### PR TITLE
docs/add-docker-hub-badges-and-section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] - 2026-05-22
+
 ### Added
 
 - `GET /paste/{id}/raw` — returns paste content as `text/plain` for CLI, programmatic, and AI agent access (MLS-186)
@@ -15,6 +19,95 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Optional `?password=` query param supported on both raw endpoints for password-protected pastes (MLS-186)
 - `PasteViewControllerTest` with raw-endpoint test coverage (MLS-186)
 - 4 raw-endpoint test methods added to `ApiPasteControllerTest` (MLS-186)
+- `.sdkmanrc` to manage SDK versions consistently across environments (MLS-158)
+
+### Changed
+
+- Upgraded all major dependencies: Kotlin 2.3.10 → 2.3.21, Spring Boot, Jackson Kotlin Module, JReleaser Maven Plugin (MLS-158)
+- Updated release workflow to use a Personal Access Token (`RELEASE_GH_TOKEN`) for PR merge step to bypass branch protection
+
+### Fixed
+
+- Improved GitHub Packages deployment error handling — gracefully skips on 409 Conflict instead of failing the workflow
+
+### Dependencies
+
+- `com.fasterxml.jackson.module:jackson-module-kotlin` bumped
+- `kotlin.version` 2.3.10 → 2.3.21
+- `org.jreleaser:jreleaser-maven-plugin` bumped
+- `docker/setup-qemu-action` 3 → 4
+
+---
+
+## [0.1.2] - 2026-04-26
+
+### Fixed
+
+- Corrected version tagging issue after the v0.1.1 release; re-released to ensure consistent artifact and tag alignment
+
+---
+
+## [0.1.1] - 2026-04-25
+
+### Fixed
+
+- Release workflow: removed duplicate Maven settings, upgraded QEMU action, switched to PR-based merge strategy for release branch to main
+
+---
+
+## [0.1.0] - 2026-04-24
+
+### Added
+
+- Form validation on abuse, paste, random, and shortener pages with disabled submit buttons and user feedback (MLS-130)
+- Generic JS form field validation with dynamic interaction handling (MLS-130)
+- `RandomNumberServiceImpl` unit tests — 14 tests covering happy path, validation, and edge cases (MLS-130)
+- Enhanced `RandomIdGeneratorServiceImplTest` with cache, uniqueness, and length checks (MLS-130)
+- Controller test for null shortener service response returning HTTP 500 (MLS-130)
+- Multi-platform Docker image support (`linux/amd64`, `linux/arm64`) via Buildx in CI (#63)
+- Validation annotations and improved error handling for `PasteRequest` fields (#40)
+- Additional SonarCloud quality badges to README (MLS-191)
+- Dependabot configuration for Maven and GitHub Actions dependency automation (#47)
+
+### Changed
+
+- Extracted and decoupled `RandomNumberService` as a functional interface (MLS-130)
+- URL shortener nullability handling in controller — returns HTTP 500 on null response (MLS-130)
+- Guarded `db.sh` PATH with Docker CLI export for reliable script execution (MLS-130)
+
+### Dependencies
+
+- `org.apache.commons:commons-lang3` 3.18.0 → 3.20.0
+- `commons-validator:commons-validator` 1.7 → 1.10.1
+- `kotlin.version` 2.3.0 → 2.3.10
+- `org.apache.commons:commons-collections4` bumped
+- `com.fasterxml.jackson.module:jackson-module-kotlin` bumped
+- `de.flapdoodle.embed:de.flapdoodle.embed.mongo` bumped
+- `docker/setup-buildx-action` 3 → 4
+- `actions/cache` 3 → 5
+- `docker/login-action` 3 → 4
+- `actions/upload-artifact` 4 → 7
+- `actions/checkout` 4 → 6
+- `org.jacoco:jacoco-maven-plugin` bumped
+- `org.jreleaser:jreleaser-maven-plugin` bumped
+
+---
+
+## [0.0.5] - 2025-11-25
+
+### Added
+
+- JReleaser configuration for fully automated releases with GitHub Actions (MLS-135)
+- Dockerfile template (`src/jreleaser/templates/docker`) for Docker Hub publishing (MLS-135)
+- Distribution configuration for `mt-link-spray` as a `SINGLE_JAR` artifact
+- JReleaser run script (`dev-ops/jreleaser-run.sh`) and test script (`dev-ops/test-jreleaser.sh`)
+- Project metadata (homepage, VCS, bug tracker, icons, screenshots) in `jreleaser.yml`
+
+### Changed
+
+- Release workflow upgraded to use Temurin JDK distribution and Docker Buildx
+- Docker image now sets active Spring profile to `prod` at build time
+- JReleaser Maven plugin upgraded to 1.21.0
 
 ---
 
@@ -48,6 +141,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 
 - Removed unused dependencies and configurations.
+
+---
 
 ## [0.0.2] - YYYY-MM-DD
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ simple steps to generate a unique link that will open all the specified URLs.
 [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=alkaphreak_marstech-link-spray&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=alkaphreak_marstech-link-spray)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=alkaphreak_marstech-link-spray&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=alkaphreak_marstech-link-spray)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=alkaphreak_marstech-link-spray&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=alkaphreak_marstech-link-spray)
+[![Docker Image Version](https://img.shields.io/docker/v/alkaphreak/marstech-link-spray/latest?label=Docker%20Hub)](https://hub.docker.com/r/alkaphreak/marstech-link-spray)
+[![Docker Pulls](https://img.shields.io/docker/pulls/alkaphreak/marstech-link-spray)](https://hub.docker.com/r/alkaphreak/marstech-link-spray)
 
 ## Features
 
@@ -250,7 +252,7 @@ echo "testcontainers.reuse.enable=true" >> $HOME/.testcontainers.properties
 
 ## Releases
 
-This project uses **JReleaser** for automated, professional releases. Current version: **0.0.5**
+This project uses **JReleaser** for automated, professional releases. Current version: **0.2.0**
 
 ### Quick Release
 1. Go to GitHub Actions → "Release" workflow
@@ -258,6 +260,31 @@ This project uses **JReleaser** for automated, professional releases. Current ve
 3. Automated release with changelog and artifacts
 
 See [RELEASE.md](RELEASE.md) for detailed release documentation.
+
+## Docker
+
+The application is available as a multi-arch Docker image (`linux/amd64`, `linux/arm64`) on Docker Hub.
+
+- Docker Hub repository: https://hub.docker.com/r/alkaphreak/marstech-link-spray
+- All tags and versions: https://hub.docker.com/r/alkaphreak/marstech-link-spray/tags
+
+### Pull and run
+
+```bash
+# Pull latest
+docker pull alkaphreak/marstech-link-spray:latest
+
+# Pull a specific version
+docker pull alkaphreak/marstech-link-spray:v0.2.0
+
+# Run (replace with your MongoDB URI)
+docker run -d \
+  --name marstech-link-spray \
+  --restart unless-stopped \
+  -p 8096:8096 \
+  -e MONGODB_URI_LINK_SPRAY="mongodb://your-mongo-host:27017/linkspray" \
+  alkaphreak/marstech-link-spray:latest
+```
 
 ## Contributing
 


### PR DESCRIPTION
docs: add Docker Hub badges, docker section, and update version to 0.2.0

Updates README.md to reflect the v0.2.0 release and improve Docker Hub discoverability.

## Changes

- Added `Docker Image Version` and `Docker Pulls` badges to the Badges section, both linking to the Docker Hub repository
- Added a new `## Docker` section after Releases with:
    - Direct links to the Docker Hub repository and tags page
    - Pull and run commands for `latest` and `v0.2.0`
- Fixed stale version reference in the Releases section (`0.0.5` → `0.2.0`)

## Related

- Release: https://github.com/alkaphreak/marstech-link-spray/releases/tag/v0.2.0
- Docker Hub: https://hub.docker.com/r/alkaphreak/marstech-link-spray