### PR TITLE
feat: Implement shortenAndSpray functionality in SprayService

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,147 @@
+# AGENTS.md — marstech-link-spray
+
+> URL shortener, link spray, paste service, and developer tools API.
+> Maintainer: Alkaphreak (Stephane Robin). YouTrack project: **MLS**.
+> For detailed Kotlin/Spring coding standards, see `.github/copilot-instructions.md`.
+
+---
+
+## Stack
+
+- **Language**: Kotlin 2.x, Java 21 (Eclipse Temurin)
+- **Framework**: Spring Boot 3.5+, Spring WebMVC
+- **Build**: Maven (`pom.xml`)
+- **DB**: MongoDB (primary) — dev `localhost:27017`, test `localhost:27018`, prod `$MONGODB_URI_LINK_SPRAY`
+- **Testing**: JUnit 5 + Mockito + MockMvc — profile `test`
+- **Releases**: JReleaser (`jreleaser.yml`) on `main` only
+- **Quality**: SonarCloud (`sonar-project.properties`)
+
+---
+
+## Codebase Map
+
+```
+src/main/kotlin/fr/marstech/mtlinkspray/
+├── conf/           # Spring configuration (SecurityConfig, ValidationConfig, etc.)
+├── controller/
+│   ├── api/        # REST API endpoints (ShortenerApiController, SprayApiController,
+│   │               #   PasteApiController, DashboardApiController,
+│   │               #   UuidApiController, RandomNumberApiController, RootApiController)
+│   ├── view/       # Thymeleaf view controllers
+│   └── commons/    # Shared controller utilities
+├── dto/            # Request/response DTOs (PasteRequest, PasteResponse, DashboardDto, …)
+├── entity/         # MongoDB documents (LinkItem, LinkItemTarget, PasteEntity,
+│                   #   AbuseReportEntity, DashboardEntity, …)
+├── enums/          # Enumerations
+├── exception/      # Custom exceptions + @ControllerAdvice handlers
+├── objects/        # Constant/static objects
+├── repository/     # Spring Data MongoDB repos (LinkItemRepository, PasteRepository,
+│                   #   DashboardRepository, AbuseReportRepository, …)
+├── service/        # Interfaces + Impl pairs (ShortenerService/Impl, SprayService/Impl,
+│                   #   PasteService/Impl, DashboardService/Impl, MailSenderService/Impl,
+│                   #   ReportAbuseService/Impl, RandomIdGeneratorService/Impl, …)
+├── utils/          # Utility functions
+└── validation/     # Custom validators
+```
+
+**Key entry points**:
+
+- `MtLinkSprayApplication.kt` — Spring Boot main
+- `ShortenerApiController` → `ShortenerService` → `LinkItemRepository` (core URL shortener flow)
+- `SprayApiController` → `SprayService` — multi-URL spray
+- `PasteApiController` → `PasteService` → `PasteRepository` — paste CRUD
+- `DashboardApiController` → `DashboardService` — collection management
+
+**Critical flows**:
+
+- Shorten URL: `POST /api/shorten` → `ShortenerApiController` → `ShortenerServiceImpl` → `LinkItemRepository` (MongoDB)
+- Resolve short code: `GET /{code}` → `RootApiController` → `ShortenerServiceImpl` → redirect
+- Create paste: `POST /api/paste` → `PasteApiController` → `PasteServiceImpl` → `PasteRepository`
+- Abuse report: `POST /api/abuse` → `ReportAbuseServiceImpl` → `MailSenderServiceImpl`
+
+---
+
+## AI Exclusions
+
+Never auto-scan or modify:
+
+- `target/` — Maven build output
+- `.local/llm/` — LLM-generated docs (read when explicitly requested)
+- `**/secrets/**`, `application-prod.properties` — credentials
+
+---
+
+## LLM Documentation Convention
+
+All AI-generated specs, analyses, and session notes go in **`.local/llm/`** — never in the project root.
+
+| Type                     | Pattern                                    | Example                          |
+|--------------------------|--------------------------------------------|----------------------------------|
+| Specification            | `{ISSUE-ID}-specification.md`              | `MLS-129-specification.md`       |
+| Implementation summary   | `{ISSUE-ID}-{PHASE}-COMPLETE.md`           | `MLS-129-PHASE2-COMPLETE.md`     |
+| Progress tracking        | `{ISSUE-ID}-progress.md`                   | `MLS-139-progress.md`            |
+| Session notes            | `{ISSUE-ID}-session{N}-{topic}.md`         | `MLS-129-session1-auth.md`       |
+
+See `.local/llm/README.md` for complete conventions.
+
+---
+
+## Key Rules for Agents
+
+- **Prefer Kotlin over Java** for all new code
+- **Constructor injection** — never `@Autowired` on fields
+- **Test method names**: camelCase only — `shouldReturnUrlWhenCodeExists()`. No backticks.
+- **Test structure**: Given-When-Then
+- **DTOs for all API responses** — never return raw entities from controllers
+- **Schema-first**: data classes with validation annotations are the contract, not comments
+- **Conventional commits** for all commit messages
+
+---
+
+## Terminal Commands
+
+```bash
+# Build + test
+rtk mvn clean verify -f /Users/marstechadmin/IdeaProjects/marstech-link-spray/pom.xml
+
+# Run dev (requires MongoDB on 27017)
+rtk mvn spring-boot:run -f /Users/marstechadmin/IdeaProjects/marstech-link-spray/pom.xml
+
+# Run tests only
+rtk mvn test -f /Users/marstechadmin/IdeaProjects/marstech-link-spray/pom.xml
+```
+
+---
+
+## External Integrations
+
+- **YouTrack**: project key `MLS` — `https://marstech.myjetbrains.com/youtrack`
+- **SonarCloud**: `alkaphreak_marstech-link-spray`
+- **Docker Hub**: `alkaphreak/marstech-link-spray`
+- **URL Shortener (self)**: `GET https://sol4.space/api/url-shortener/shorten?url={url}`
+
+---
+
+## Living Documentation
+
+When adding or modifying a feature, update this file:
+
+- Add new controllers/services to the Codebase Map
+- Update Critical flows if a new flow is introduced
+- Record any new naming conventions or project-specific patterns
+
+---
+
+## Graphify Knowledge Graph
+
+If `graphify-out/` exists at the repo root:
+
+```bash
+MyGraphify /Users/marstechadmin/IdeaProjects/marstech-link-spray
+/graphify query "find all callers of ShortenerService"
+/graphify explain "URL resolution flow"
+```
+
+---
+
+_Last updated: 2026-06-04 — MARSTECH-643 AGENTS.md standard rollout_

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,11 +136,11 @@ When adding or modifying a feature, update this file:
 
 If `graphify-out/` exists at the repo root:
 
-```bash
-MyGraphify /Users/marstechadmin/IdeaProjects/marstech-link-spray
+~~~bash
+MyGraphify .
 /graphify query "find all callers of ShortenerService"
 /graphify explain "URL resolution flow"
-```
+~~~
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,12 +75,12 @@ Never auto-scan or modify:
 
 All AI-generated specs, analyses, and session notes go in **`.local/llm/`** — never in the project root.
 
-| Type                     | Pattern                                    | Example                          |
-|--------------------------|--------------------------------------------|----------------------------------|
-| Specification            | `{ISSUE-ID}-specification.md`              | `MLS-129-specification.md`       |
-| Implementation summary   | `{ISSUE-ID}-{PHASE}-COMPLETE.md`           | `MLS-129-PHASE2-COMPLETE.md`     |
-| Progress tracking        | `{ISSUE-ID}-progress.md`                   | `MLS-139-progress.md`            |
-| Session notes            | `{ISSUE-ID}-session{N}-{topic}.md`         | `MLS-129-session1-auth.md`       |
+| Type                   | Pattern                            | Example                      |
+|------------------------|------------------------------------|------------------------------|
+| Specification          | `{ISSUE-ID}-specification.md`      | `MLS-129-specification.md`   |
+| Implementation summary | `{ISSUE-ID}-{PHASE}-COMPLETE.md`   | `MLS-129-PHASE2-COMPLETE.md` |
+| Progress tracking      | `{ISSUE-ID}-progress.md`           | `MLS-139-progress.md`        |
+| Session notes          | `{ISSUE-ID}-session{N}-{topic}.md` | `MLS-129-session1-auth.md`   |
 
 See `.local/llm/README.md` for complete conventions.
 
@@ -88,7 +88,7 @@ See `.local/llm/README.md` for complete conventions.
 
 ## Key Rules for Agents
 
-- **Prefer Kotlin over Java** for all new code
+- **Prefer Kotlin to Java** for all new code
 - **Constructor injection** — never `@Autowired` on fields
 - **Test method names**: camelCase only — `shouldReturnUrlWhenCodeExists()`. No backticks.
 - **Test structure**: Given-When-Then
@@ -100,15 +100,17 @@ See `.local/llm/README.md` for complete conventions.
 
 ## Terminal Commands
 
+From the project root and using rtk :
+
 ```bash
 # Build + test
-rtk mvn clean verify -f /Users/marstechadmin/IdeaProjects/marstech-link-spray/pom.xml
+rtk mvn clean verify -f pom.xml
 
 # Run dev (requires MongoDB on 27017)
-rtk mvn spring-boot:run -f /Users/marstechadmin/IdeaProjects/marstech-link-spray/pom.xml
+rtk mvn spring-boot:run -f pom.xml
 
 # Run tests only
-rtk mvn test -f /Users/marstechadmin/IdeaProjects/marstech-link-spray/pom.xml
+rtk mvn test -f pom.xml
 ```
 
 ---

--- a/src/main/kotlin/fr/marstech/mtlinkspray/controller/api/SprayApiController.kt
+++ b/src/main/kotlin/fr/marstech/mtlinkspray/controller/api/SprayApiController.kt
@@ -14,7 +14,9 @@ import org.springframework.web.bind.annotation.RestController
 @Validated
 @RestController
 @RequestMapping("/api/spray")
-class SprayApiController {
+class SprayApiController(
+    private val sprayService: SprayService
+) {
 
     @GetMapping
     fun getSprayLink(
@@ -23,6 +25,12 @@ class SprayApiController {
         @NotEmptyNotBlank
         @ValidUrlList(maxSize = 100, message = "Invalid URL list")
         inputLinkList: List<String>,
+        @RequestParam(defaultValue = "false")
+        shorten: Boolean = false,
     ): String =
-        SprayService.getLinkSpray(httpServletRequest, inputLinkList)
+        if (shorten) {
+            sprayService.shortenAndSpray(inputLinkList, httpServletRequest)
+        } else {
+            SprayService.getLinkSpray(httpServletRequest, inputLinkList)
+        }
 }

--- a/src/main/kotlin/fr/marstech/mtlinkspray/controller/view/ViewSprayController.kt
+++ b/src/main/kotlin/fr/marstech/mtlinkspray/controller/view/ViewSprayController.kt
@@ -1,6 +1,7 @@
 package fr.marstech.mtlinkspray.controller.view
 
 import fr.marstech.mtlinkspray.enums.ViewNameEnum.SPRAY
+import fr.marstech.mtlinkspray.service.SprayService
 import fr.marstech.mtlinkspray.service.SprayService.Companion.getLinkList
 import fr.marstech.mtlinkspray.service.SprayService.Companion.getLinkListText
 import fr.marstech.mtlinkspray.service.SprayService.Companion.getLinkSpray
@@ -15,7 +16,9 @@ import org.springframework.web.servlet.ModelAndView
 
 @Controller
 @RequestMapping("/spray")
-class ViewSprayController : ThymeleafViewControllerInterface {
+class ViewSprayController(
+    private val sprayService: SprayService
+) : ThymeleafViewControllerInterface {
 
     @GetMapping
     fun getSprayPage(httpServletRequest: HttpServletRequest): ModelAndView =
@@ -28,6 +31,19 @@ class ViewSprayController : ThymeleafViewControllerInterface {
         getModelAndView().addObject("linkList", linkList)
             .addObject("linkListText", getLinkListText(linkList))
             .addObject("linkSpray", getLinkSpray(httpServletRequest, linkList))
+    }
+
+    @PostMapping("/shorten")
+    fun getShortenedSpray(
+        @RequestParam inputLinkList: String, httpServletRequest: HttpServletRequest
+    ): ModelAndView {
+        val linkList = getLinkList(inputLinkList)
+        val shortenedSprayUrl = sprayService.shortenAndSpray(linkList, httpServletRequest)
+        return getModelAndView()
+            .addObject("linkList", linkList)
+            .addObject("linkListText", getLinkListText(linkList))
+            .addObject("linkSpray", shortenedSprayUrl)
+            .addObject("linkSprayShortened", true)
     }
 
     @GetMapping("/open")

--- a/src/main/kotlin/fr/marstech/mtlinkspray/service/SprayService.kt
+++ b/src/main/kotlin/fr/marstech/mtlinkspray/service/SprayService.kt
@@ -8,6 +8,17 @@ import jakarta.servlet.http.HttpServletRequest
 import org.springframework.web.util.UriComponentsBuilder
 
 interface SprayService {
+
+    /**
+     * Shortens each URL in the list, builds a spray link from the shortened URLs,
+     * then shortens the resulting spray link into a single short URL.
+     *
+     * @param urls               the list of raw target URLs
+     * @param httpServletRequest the current HTTP request (used to build absolute URLs)
+     * @return a single shortened URL that redirects to a spray page of shortened links
+     */
+    fun shortenAndSpray(urls: List<String>, httpServletRequest: HttpServletRequest): String
+
     companion object {
 
         /**

--- a/src/main/kotlin/fr/marstech/mtlinkspray/service/SprayServiceImpl.kt
+++ b/src/main/kotlin/fr/marstech/mtlinkspray/service/SprayServiceImpl.kt
@@ -17,7 +17,7 @@ class SprayServiceImpl(
     override fun shortenAndSpray(urls: List<String>, httpServletRequest: HttpServletRequest): String {
         val shortenedUrls = urls.map { url ->
             shortenerService.shorten(url, httpServletRequest)
-                ?: throw UrlShorteningException("Failed to shorten URL: $url", null)
+                ?: throw UrlShorteningException("Failed to shorten URL", null)
         }
         val sprayUrl = getLinkSpray(httpServletRequest, shortenedUrls)
         return shortenerService.shorten(sprayUrl, httpServletRequest)

--- a/src/main/kotlin/fr/marstech/mtlinkspray/service/SprayServiceImpl.kt
+++ b/src/main/kotlin/fr/marstech/mtlinkspray/service/SprayServiceImpl.kt
@@ -1,6 +1,26 @@
 package fr.marstech.mtlinkspray.service
 
+import fr.marstech.mtlinkspray.exception.UrlShorteningException
+import fr.marstech.mtlinkspray.service.SprayService.Companion.getLinkSpray
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.stereotype.Service
 
 @Service
-class SprayServiceImpl : SprayService
+class SprayServiceImpl(
+    private val shortenerService: ShortenerService
+) : SprayService {
+
+    /**
+     * Shortens every URL in the list, builds a spray link from the shortened URLs,
+     * then shortens that spray link into a single short URL.
+     */
+    override fun shortenAndSpray(urls: List<String>, httpServletRequest: HttpServletRequest): String {
+        val shortenedUrls = urls.map { url ->
+            shortenerService.shorten(url, httpServletRequest)
+                ?: throw UrlShorteningException("Failed to shorten URL: $url", null)
+        }
+        val sprayUrl = getLinkSpray(httpServletRequest, shortenedUrls)
+        return shortenerService.shorten(sprayUrl, httpServletRequest)
+            ?: throw UrlShorteningException("Failed to shorten spray URL", null)
+    }
+}

--- a/src/main/resources/templates/spray.html
+++ b/src/main/resources/templates/spray.html
@@ -71,6 +71,20 @@
                 <p>
                     Test with the link: <a th:href="@{${linkSpray}}">Spray</a>
                 </p>
+
+                <!--/*@thymesVar id="linkSprayShortened" type="java.lang.Boolean"*/-->
+                <div th:unless="${linkSprayShortened}">
+                    <form accept-charset="UTF-8" action="/spray/shorten" method="post"
+                          th:action="@{/spray/shorten}">
+                        <input type="hidden" name="inputLinkList" th:value="${linkListText}"/>
+                        <button class="btn btn-outline-secondary btn-sm" type="submit">
+                            <i class="bi bi-scissors"></i> Shorten Spray
+                        </button>
+                    </form>
+                </div>
+                <div th:if="${linkSprayShortened}">
+                    <span class="badge text-bg-success"><i class="bi bi-check-circle"></i> All URLs and the spray link have been shortened</span>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/spray.html
+++ b/src/main/resources/templates/spray.html
@@ -83,7 +83,7 @@
                     </form>
                 </div>
                 <div th:if="${linkSprayShortened}">
-                    <span class="badge text-bg-success"><i class="bi bi-check-circle"></i> All URLs and the spray link have been shortened</span>
+                    <span class="badge text-bg-success"><i class="bi bi-check-circle"></i> The spray link has been shortened</span>
                 </div>
             </div>
         </div>

--- a/src/test/kotlin/fr/marstech/mtlinkspray/controller/ViewSprayControllerTest.kt
+++ b/src/test/kotlin/fr/marstech/mtlinkspray/controller/ViewSprayControllerTest.kt
@@ -1,7 +1,10 @@
 package fr.marstech.mtlinkspray.controller
 
 import fr.marstech.mtlinkspray.controller.view.ViewSprayController
+import fr.marstech.mtlinkspray.service.SprayService
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.web.servlet.ModelAndView
 import kotlin.test.assertEquals
@@ -10,7 +13,8 @@ import kotlin.test.assertTrue
 
 class ViewSprayControllerTest {
 
-    private val controller = ViewSprayController()
+    private val sprayService: SprayService = mock(SprayService::class.java)
+    private val controller = ViewSprayController(sprayService)
 
     @Test
     fun getSprayPageShouldReturnCorrectView() {
@@ -55,5 +59,24 @@ class ViewSprayControllerTest {
         assertEquals("spray", result.viewName)
         assertNotNull(result.model["linkListText"])
         assertNotNull(result.model["spray"])
+    }
+
+    @Test
+    fun postShortenedSprayShouldReturnCorrectViewWithShortenedLink() {
+        // Given
+        val request = MockHttpServletRequest()
+        val shortenedUrl = "http://localhost/abc123"
+        `when`(sprayService.shortenAndSpray(listOf("https://example.com"), request))
+            .thenReturn(shortenedUrl)
+
+        // When
+        val result: ModelAndView = controller.getShortenedSpray("https://example.com", request)
+
+        // Then
+        assertEquals("spray", result.viewName)
+        assertNotNull(result.model["linkList"])
+        assertNotNull(result.model["linkListText"])
+        assertEquals(shortenedUrl, result.model["linkSpray"])
+        assertEquals(true, result.model["linkSprayShortened"])
     }
 }

--- a/src/test/kotlin/fr/marstech/mtlinkspray/controller/api/SprayApiControllerTest.kt
+++ b/src/test/kotlin/fr/marstech/mtlinkspray/controller/api/SprayApiControllerTest.kt
@@ -1,8 +1,12 @@
 package fr.marstech.mtlinkspray.controller.api
 
+import fr.marstech.mtlinkspray.service.SprayService
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -13,6 +17,9 @@ class SprayApiControllerTest {
 
     @Autowired
     lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    lateinit var sprayService: SprayService
 
     @Test
     fun getSprayReturnsExpectedResult() {
@@ -61,6 +68,33 @@ class SprayApiControllerTest {
 
         get("/api/spray")
             .param("inputLinkList", "https://a.com", "https://b.com", "https://c.com")
+            .let(mockMvc::perform)
+            .andExpect(status().isOk)
+            .andExpect(content().string(expectedResponse))
+    }
+
+    @Test
+    fun shouldReturnShortenedSprayLinkWhenShortenIsTrue() {
+        // Given
+        val expectedShortUrl = "http://localhost/xyz789"
+        whenever(sprayService.shortenAndSpray(any(), any())).thenReturn(expectedShortUrl)
+
+        // When / Then
+        get("/api/spray")
+            .param("inputLinkList", "https://example.com", "https://example.org")
+            .param("shorten", "true")
+            .let(mockMvc::perform)
+            .andExpect(status().isOk)
+            .andExpect(content().string(expectedShortUrl))
+    }
+
+    @Test
+    fun shouldReturnRawSprayLinkWhenShortenIsFalse() {
+        val expectedResponse = "http://localhost/spray/open?spray=https://example.com&spray=https://example.org"
+
+        get("/api/spray")
+            .param("inputLinkList", "https://example.com", "https://example.org")
+            .param("shorten", "false")
             .let(mockMvc::perform)
             .andExpect(status().isOk)
             .andExpect(content().string(expectedResponse))

--- a/src/test/kotlin/fr/marstech/mtlinkspray/service/SprayServiceImplTest.kt
+++ b/src/test/kotlin/fr/marstech/mtlinkspray/service/SprayServiceImplTest.kt
@@ -1,0 +1,89 @@
+package fr.marstech.mtlinkspray.service
+
+import fr.marstech.mtlinkspray.exception.UrlShorteningException
+import jakarta.servlet.http.HttpServletRequest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+internal class SprayServiceImplTest {
+
+    private val shortenerService: ShortenerService = mock(ShortenerService::class.java)
+    private val sprayService: SprayService = SprayServiceImpl(shortenerService)
+    private lateinit var httpServletRequest: HttpServletRequest
+
+    @BeforeEach
+    fun setUp() {
+        httpServletRequest = mock(HttpServletRequest::class.java)
+        `when`(httpServletRequest.serverName).thenReturn("localhost")
+        `when`(httpServletRequest.serverPort).thenReturn(80)
+        `when`(httpServletRequest.scheme).thenReturn("http")
+    }
+
+    @Test
+    fun shortenAndSprayShouldReturnShortenedSprayUrl() {
+        // Given
+        val urls = listOf("https://example.com", "https://example.org")
+        val shortUrl1 = "http://localhost/abc"
+        val shortUrl2 = "http://localhost/def"
+        val finalShortUrl = "http://localhost/xyz"
+
+        `when`(shortenerService.shorten("https://example.com", httpServletRequest)).thenReturn(shortUrl1)
+        `when`(shortenerService.shorten("https://example.org", httpServletRequest)).thenReturn(shortUrl2)
+        val sprayUrl = SprayService.getLinkSpray(httpServletRequest, listOf(shortUrl1, shortUrl2))
+        `when`(shortenerService.shorten(sprayUrl, httpServletRequest)).thenReturn(finalShortUrl)
+
+        // When
+        val result = sprayService.shortenAndSpray(urls, httpServletRequest)
+
+        // Then
+        assertEquals(finalShortUrl, result)
+    }
+
+    @Test
+    fun shortenAndSprayShouldThrowExceptionWhenUrlShorteningFails() {
+        // Given
+        val urls = listOf("https://example.com")
+        `when`(shortenerService.shorten("https://example.com", httpServletRequest)).thenReturn(null)
+
+        // When / Then
+        assertThrows(UrlShorteningException::class.java) {
+            sprayService.shortenAndSpray(urls, httpServletRequest)
+        }
+    }
+
+    @Test
+    fun shortenAndSprayShouldThrowExceptionWhenSprayUrlShorteningFails() {
+        // Given
+        val urls = listOf("https://example.com")
+        val shortUrl = "http://localhost/abc"
+        `when`(shortenerService.shorten("https://example.com", httpServletRequest)).thenReturn(shortUrl)
+        val sprayUrl = SprayService.getLinkSpray(httpServletRequest, listOf(shortUrl))
+        `when`(shortenerService.shorten(sprayUrl, httpServletRequest)).thenReturn(null)
+
+        // When / Then
+        assertThrows(UrlShorteningException::class.java) {
+            sprayService.shortenAndSpray(urls, httpServletRequest)
+        }
+    }
+
+    @Test
+    fun shortenAndSprayShouldHandleSingleUrl() {
+        // Given
+        val urls = listOf("https://single.example.com")
+        val shortUrl = "http://localhost/s1"
+        val finalShortUrl = "http://localhost/final"
+        `when`(shortenerService.shorten("https://single.example.com", httpServletRequest)).thenReturn(shortUrl)
+        val sprayUrl = SprayService.getLinkSpray(httpServletRequest, listOf(shortUrl))
+        `when`(shortenerService.shorten(sprayUrl, httpServletRequest)).thenReturn(finalShortUrl)
+
+        // When
+        val result = sprayService.shortenAndSpray(urls, httpServletRequest)
+
+        // Then
+        assertEquals(finalShortUrl, result)
+    }
+}


### PR DESCRIPTION
This pull request introduces a new "shorten and spray" feature to the link spray functionality, allowing users to generate a single short URL that, when visited, opens a spray page of individually-shortened URLs. The change is implemented across the API, view controllers, service layer, and is thoroughly tested. Additionally, the project documentation (`AGENTS.md`) is updated to reflect current conventions and architecture.

**Feature: Shorten and Spray**

* Added a new `shortenAndSpray` method to the `SprayService` interface and implemented it in `SprayServiceImpl`. This method shortens each input URL, creates a spray link from the shortened URLs, and then shortens the spray link itself, returning a single short URL. Proper error handling is included for failed shortening operations. [[1]](diffhunk://#diff-9c1f49e91e2d86322fd0e2d38cd4b47e2d584a9327069542ae33d56114d72ef8R11-R21) [[2]](diffhunk://#diff-9f520566aaa8332ca146606b09449171ef1d321438bfc61c7cbae22828ed147eR3-R26)
* Updated `SprayApiController` and `ViewSprayController` to support the new feature, allowing API and web users to request a shortened spray link via a `shorten` parameter or a new form action. [[1]](diffhunk://#diff-1bf272c3e2c645c20f9a3b4ac274f170c027291d0a04313a7437afb8b9e77985L17-R19) [[2]](diffhunk://#diff-1bf272c3e2c645c20f9a3b4ac274f170c027291d0a04313a7437afb8b9e77985R28-R36) [[3]](diffhunk://#diff-eb88258f526ccd1c6077f505a4aa0ae13bdb47d0cc3fc1cf70ad6790bda39ef2R4) [[4]](diffhunk://#diff-eb88258f526ccd1c6077f505a4aa0ae13bdb47d0cc3fc1cf70ad6790bda39ef2L18-R21) [[5]](diffhunk://#diff-eb88258f526ccd1c6077f505a4aa0ae13bdb47d0cc3fc1cf70ad6790bda39ef2R36-R48)
* Modified the `spray.html` template to add a "Shorten Spray" button and display UI feedback when the operation is successful.

**Testing**

* Added comprehensive unit and controller tests for the new `shortenAndSpray` logic, including success and failure cases, and verified correct integration in both API and view layers. [[1]](diffhunk://#diff-2a41291ef18447b29f2fb5980e9be2eaa6e9f91fc64cfeef1f142a9f78999e3bR4-R7) [[2]](diffhunk://#diff-2a41291ef18447b29f2fb5980e9be2eaa6e9f91fc64cfeef1f142a9f78999e3bL13-R17) [[3]](diffhunk://#diff-2a41291ef18447b29f2fb5980e9be2eaa6e9f91fc64cfeef1f142a9f78999e3bR63-R81) [[4]](diffhunk://#diff-5c465bb9dd6922716e4b05e9b6a5572634738689e582afaf1fa275bec38440f9R3-R9) [[5]](diffhunk://#diff-5c465bb9dd6922716e4b05e9b6a5572634738689e582afaf1fa275bec38440f9R21-R23) [[6]](diffhunk://#diff-5c465bb9dd6922716e4b05e9b6a5572634738689e582afaf1fa275bec38440f9R75-R101) [[7]](diffhunk://#diff-04c25083230cd204d3f30a13cdc325e1977f4b22b07041a8b35c232dddf6910aR1-R89)

**Documentation**

* Introduced and updated `AGENTS.md` to provide a detailed, up-to-date overview of the codebase, stack, conventions, and documentation rules for the project.