### PR TITLE
refactor: Simplify coroutine scope and update mock usage in tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,6 +31,7 @@
 **/vendor
 LICENSE
 README.md
+**/*.iml
 **/*.ipr
 **/*.iws
 **/*.log

--- a/.dockerignore
+++ b/.dockerignore
@@ -31,7 +31,6 @@
 **/vendor
 LICENSE
 README.md
-**/*.iml
 **/*.ipr
 **/*.iws
 **/*.log

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -366,7 +366,7 @@ permissions:
   contents: write
 ```
 
-2) Ensure actions/checkout persists credentials
+1) Ensure actions/checkout persists credentials
 
 Make the checkout step explicitly persist credentials so the `GITHUB_TOKEN` is available to `git` for pushing:
 
@@ -381,11 +381,11 @@ Make the checkout step explicitly persist credentials so the `GITHUB_TOKEN` is a
 
 (actions/checkout default is usually `persist-credentials: true`, but some runners or workflows explicitly set read-only defaults — setting it explicitly avoids ambiguity.)
 
-3) Check repository Actions permissions
+1) Check repository Actions permissions
 
 Go to: Repository Settings → Actions → General → Workflow permissions. Ensure it's set to "Read and write permissions" (not "Read repository contents only").
 
-4) Fallback: Use a Personal Access Token (PAT)
+1) Fallback: Use a Personal Access Token (PAT)
 
 If your organization or repo policy blocks `GITHUB_TOKEN` writes (common in some orgs), create a GitHub Personal Access Token with `repo` scope and store it as a secret (for example `REPO_PAT`). Then change the push step to use it explicitly:
 
@@ -397,11 +397,11 @@ git push origin "$BRANCH_NAME"
 
 Or use `actions/setup-git-credentials`-style actions that accept a token input.
 
-5) Make sure the workflow run is not from an untrusted fork
+1) Make sure the workflow run is not from an untrusted fork
 
 Workflows triggered by pull requests from forks run with reduced permissions and cannot push back to the main repository. Trigger releases from the protected `main` branch (via `workflow_dispatch`) or from trusted runs.
 
-6) Verify Git user is configured
+1) Verify Git user is configured
 
 The workflow already configures `git config user.email` and `user.name` — keep those lines. The missing piece in your logs was authentication, not username config.
 

--- a/http-tests/dashboard-api.http
+++ b/http-tests/dashboard-api.http
@@ -67,3 +67,5 @@ Content-Type: application/json
   "name": "Invalid",
   "description": "",
   "items": []
+}
+

--- a/http-tests/error-handling.http
+++ b/http-tests/error-handling.http
@@ -24,6 +24,8 @@ Content-Type: application/json
 {
   "invalid": "json",
   "missing": "closing brace"
+}
+
 
 ### Test 400 - Missing required parameter
 GET {{baseUrl}}/api/url-shortener/shorten

--- a/http-tests/security-tests.http
+++ b/http-tests/security-tests.http
@@ -49,7 +49,10 @@ POST {{baseUrl}}/api/paste
 Content-Type: application/json
 
 {
-  "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. ".repeat(1000)
+  "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. ".repeat(1000),
+  "language": "",
+  "expiration": "",
+  "isPrivate": false
 }
 
 ### Header Injection Test
@@ -66,7 +69,10 @@ Content-Type: application/json
 
 {
   "title": "Unicode Test 🚀",
-  "content": "Testing unicode: 你好世界 🌍 émojis 🎉 and special chars: ñáéíóú"
+  "content": "Testing unicode: 你好世界 🌍 émojis 🎉 and special chars: ñáéíóú",
+  "language": "",
+  "expiration": "",
+  "isPrivate": false
 }
 
 ### Null Byte Test

--- a/src/main/kotlin/fr/marstech/mtlinkspray/conf/ApplicationReadyEventHandlerForDev.kt
+++ b/src/main/kotlin/fr/marstech/mtlinkspray/conf/ApplicationReadyEventHandlerForDev.kt
@@ -2,6 +2,7 @@ package fr.marstech.mtlinkspray.conf
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -11,20 +12,19 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.context.event.EventListener
 import org.springframework.core.env.Environment
+import kotlin.time.Duration.Companion.milliseconds
 
 @Configuration
 @Profile("dev")
 class ApplicationReadyEventHandlerForDev(
     private val environment: Environment,
+    @param:Value($$"${mt.link-spray.version:unknown}") private val mtLinkSprayVersion: String,
 ) {
-    @Value($$"${mt.link-spray.version}")
-    private var mtLinkSprayVersion: String = "unknown"
-
-    private val scope = CoroutineScope(Dispatchers.Default)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     @EventListener(ApplicationReadyEvent::class)
     fun displayServerUrlInConsole() = scope.launch {
-        kotlinx.coroutines.delay(1000)
+        kotlinx.coroutines.delay(1000.milliseconds)
         displayLocalServerInfo()
     }
 

--- a/src/main/kotlin/fr/marstech/mtlinkspray/service/DashboardServiceImpl.kt
+++ b/src/main/kotlin/fr/marstech/mtlinkspray/service/DashboardServiceImpl.kt
@@ -2,13 +2,11 @@ package fr.marstech.mtlinkspray.service
 
 import fr.marstech.mtlinkspray.dto.DashboardDto
 import fr.marstech.mtlinkspray.entity.DashboardEntity
-import fr.marstech.mtlinkspray.entity.DashboardItem
 import fr.marstech.mtlinkspray.entity.HistoryItem
 import fr.marstech.mtlinkspray.repository.DashboardRepository
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.*
-import java.util.Map
 
 @Service
 class DashboardServiceImpl(
@@ -21,9 +19,9 @@ class DashboardServiceImpl(
         null,
         true,
         dashboardDto.description,
-        Map.of<String, String>(),
+        mutableMapOf(),
         HistoryItem(),
-        mutableListOf<HistoryItem>(),
+        mutableListOf(),
         dashboardDto.name,
         dashboardDto.items
     ).let {
@@ -36,7 +34,7 @@ class DashboardServiceImpl(
         DashboardDto(
             id = UUID.randomUUID().toString(),
             name = dashboardName,
-            items = mutableListOf<DashboardItem>(),
+            items = mutableListOf(),
             description = null
         )
     )

--- a/src/main/kotlin/fr/marstech/mtlinkspray/service/RandomIdGeneratorServiceImpl.kt
+++ b/src/main/kotlin/fr/marstech/mtlinkspray/service/RandomIdGeneratorServiceImpl.kt
@@ -7,26 +7,14 @@ import org.springframework.stereotype.Service
 
 @Service
 class RandomIdGeneratorServiceImpl(
-    val linkItemRepository: LinkItemRepository
+    private val linkItemRepository: LinkItemRepository,
+    @param:Value($$"${mt.link-spray.random-id.length}") val length: Int,
+    @param:Value($$"${mt.link-spray.random-id.cache.enabled}") val isCacheEnabled: Boolean,
+    @param:Value($$"${mt.link-spray.random-id.cache.depth}") val cacheDepth: Int,
+    @param:Value($$"${mt.link-spray.random-id.cache.treshold}") val cacheTreshold: Int,
+    @param:Value($$"${mt.link-spray.random-id.prefix}") private val prefix: String,
+    @param:Value($$"${mt.link-spray.random-id.charset}") private val charset: String,
 ) : RandomIdGeneratorService {
-
-    @Value($$"${mt.link-spray.random-id.length}")
-    var length: Int = 0
-
-    @Value($$"${mt.link-spray.random-id.cache.enabled}")
-    val isCacheEnabled: Boolean = true
-
-    @Value($$"${mt.link-spray.random-id.cache.depth}")
-    val cacheDepth: Int = 100
-
-    @Value($$"${mt.link-spray.random-id.cache.treshold}")
-    val cacheTreshold: Int = 10
-
-    @Value($$"${mt.link-spray.random-id.prefix}")
-    val prefix: String = ""
-
-    @Value($$"${mt.link-spray.random-id.charset}")
-    val charset: String = (0..127).map(Int::toChar).joinToString("")
 
     val cacheIds: LinkedHashSet<String> = LinkedHashSet()
 

--- a/src/main/kotlin/fr/marstech/mtlinkspray/service/ShortenerServiceImpl.kt
+++ b/src/main/kotlin/fr/marstech/mtlinkspray/service/ShortenerServiceImpl.kt
@@ -29,7 +29,7 @@ class ShortenerServiceImpl(
         description = null,
         metadata = Map.of<String, String>(),
         author = HistoryItem(),
-        historyItems = mutableListOf<HistoryItem>(),
+        historyItems = mutableListOf(),
         target = LinkItemTarget(url)
     ).let { linkItemRepository.save(it) }
         .let {
@@ -43,7 +43,7 @@ class ShortenerServiceImpl(
         uid: String,
     ): String =
         linkItemRepository.findById(uid)
-            .orElseThrow<ChangeSetPersister.NotFoundException?>(
+            .orElseThrow(
                 Supplier { ChangeSetPersister.NotFoundException() })
             .target
             .targetUrl

--- a/src/main/kotlin/fr/marstech/mtlinkspray/validation/NotEmptyNotBlank.kt
+++ b/src/main/kotlin/fr/marstech/mtlinkspray/validation/NotEmptyNotBlank.kt
@@ -18,7 +18,6 @@ annotation class NotEmptyNotBlank(
     val payload: Array<KClass<out Payload>> = []
 )
 
-@Suppress("unused")
 class NotEmptyNotBlankValidator : ConstraintValidator<NotEmptyNotBlank, List<String>> {
     override fun isValid(value: List<String>?, context: ConstraintValidatorContext?): Boolean =
         !value.isNullOrEmpty() && value.all(String::isNotBlank)

--- a/src/main/kotlin/fr/marstech/mtlinkspray/validation/ValidUrlList.kt
+++ b/src/main/kotlin/fr/marstech/mtlinkspray/validation/ValidUrlList.kt
@@ -116,21 +116,20 @@ class ValidUrlListValidator : ConstraintValidator<ValidUrlList, List<String>> {
         }
 
         // Check if URI has a scheme (protocol)
-        val scheme = uri.scheme?.lowercase()
-        if (scheme == null) {
-            return "URL must have a protocol (e.g., http:// or https://)"
-        }
+        val scheme = uri.scheme?.lowercase() ?: return "URL must have a protocol (e.g., http:// or https://)"
 
         // Check if scheme is allowed
-        if (scheme !in allowedProtocols) {
-            return "URL protocol must be one of: ${allowedProtocols.joinToString(", ")}"
-        }
+        return when {
+            scheme !in allowedProtocols -> {
+                "URL protocol must be one of: ${allowedProtocols.joinToString(", ")}"
+            }
 
-        // Check if URI has a valid host for absolute URIs
-        if (uri.isAbsolute && uri.host.isNullOrBlank()) {
-            return "URL must have a valid host"
-        }
+            // Check if URI has a valid host for absolute URIs
+            uri.isAbsolute && uri.host.isNullOrBlank() -> {
+                "URL must have a valid host"
+            }
 
-        return null // No error
+            else -> null
+        } // No error
     }
 }

--- a/src/test/kotlin/fr/marstech/mtlinkspray/conf/ApplicationReadyEventHandlerForDevTest.kt
+++ b/src/test/kotlin/fr/marstech/mtlinkspray/conf/ApplicationReadyEventHandlerForDevTest.kt
@@ -1,32 +1,32 @@
 package fr.marstech.mtlinkspray.conf
 
-import fr.marstech.mtlinkspray.repository.MtLinkSprayCollectionRepository
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.springframework.core.env.Environment
 
 class ApplicationReadyEventHandlerForDevTest {
 
     private lateinit var environment: Environment
-    private lateinit var repository: MtLinkSprayCollectionRepository
     private lateinit var handler: ApplicationReadyEventHandlerForDev
 
     @BeforeEach
     fun setup() {
-        environment = mock(Environment::class.java)
-        repository = mock(MtLinkSprayCollectionRepository::class.java)
-        handler = ApplicationReadyEventHandlerForDev(environment)
+        environment = mock()
+        handler = ApplicationReadyEventHandlerForDev(environment, "1.0.0-test")
     }
 
     @Test
     fun displayServerUrlInConsoleLogsServerUrl() {
-        runBlocking {
-            `when`(environment.getProperty("server.port")).thenReturn("8080")
-            handler.displayServerUrlInConsole()
-            // Check logs manually or with a log-capturing library
-        }
+        // Given
+        whenever(environment.getProperty("server.port")).thenReturn("8080")
+
+        // When
+        val job = handler.displayServerUrlInConsole()
+
+        // Then - job is launched without exception
+        runBlocking { job.join() }
     }
 }

--- a/src/test/kotlin/fr/marstech/mtlinkspray/controller/commons/GlobalRestExceptionHandlerTest.kt
+++ b/src/test/kotlin/fr/marstech/mtlinkspray/controller/commons/GlobalRestExceptionHandlerTest.kt
@@ -1,9 +1,7 @@
 package fr.marstech.mtlinkspray.controller.commons
 
 import jakarta.validation.ConstraintViolationException
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
@@ -19,9 +17,11 @@ import org.springframework.web.context.request.WebRequest
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 
 // Top-level dummy used by several tests
-@Suppress("unused", "UNUSED_PARAMETER")
+@Suppress("UNUSED_PARAMETER")
 class Dummy {
-    fun method(param: String) {}
+    fun method(param: String) {
+        // No implementation needed for testing purposes
+    }
 }
 
 class GlobalRestExceptionHandlerTest {

--- a/src/test/kotlin/fr/marstech/mtlinkspray/service/RandomIdGeneratorServiceImplTest.kt
+++ b/src/test/kotlin/fr/marstech/mtlinkspray/service/RandomIdGeneratorServiceImplTest.kt
@@ -5,7 +5,13 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty
-import org.mockito.Mockito.*
+import org.mockito.Mockito.atLeastOnce
+import org.mockito.Mockito.never
+import org.mockito.Mockito.reset
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -81,7 +87,7 @@ class RandomIdGeneratorServiceImplTest {
     @Test
     fun getGeneratedFreeIdShouldDelegateToWithCacheWhenCacheEnabled() {
         // Given
-        `when`(linkItemRepository.findAllIds()).thenReturn(emptyList())
+        whenever(linkItemRepository.findAllIds()).thenReturn(emptyList())
 
         // When
         val id = randomIdGeneratorService.getGeneratedFreeId()
@@ -94,7 +100,7 @@ class RandomIdGeneratorServiceImplTest {
     @Test
     fun getGeneratedFreeIdWithoutCacheShouldReturnIdOnFirstAttempt() {
         // Given
-        `when`(linkItemRepository.existsById(anyString())).thenReturn(false)
+        whenever(linkItemRepository.existsById(anyOrNull())).thenReturn(false)
 
         // When
         val id = randomIdGeneratorService.getGeneratedFreeIdWithoutCache()
@@ -107,7 +113,7 @@ class RandomIdGeneratorServiceImplTest {
     @Test
     fun getGeneratedFreeIdWithoutCacheShouldRetryWhenIdAlreadyExists() {
         // Given — first 3 generated ids are taken, the 4th is free
-        `when`(linkItemRepository.existsById(anyString()))
+        whenever(linkItemRepository.existsById(anyOrNull()))
             .thenReturn(true)
             .thenReturn(true)
             .thenReturn(true)
@@ -118,13 +124,13 @@ class RandomIdGeneratorServiceImplTest {
 
         // Then
         assertNotNull(id)
-        verify(linkItemRepository, times(4)).existsById(anyString())
+        verify(linkItemRepository, times(4)).existsById(anyOrNull())
     }
 
     @Test
     fun getGeneratedFreeIdWithoutCacheShouldThrowWhenMaxAttemptsExceeded() {
         // Given — all attempts return true (id always taken)
-        `when`(linkItemRepository.existsById(anyString())).thenReturn(true)
+        whenever(linkItemRepository.existsById(anyOrNull())).thenReturn(true)
 
         // When / Then
         assertThrows(IllegalStateException::class.java) {
@@ -135,7 +141,7 @@ class RandomIdGeneratorServiceImplTest {
     @Test
     fun getGeneratedFreeIdWithCacheShouldReturnIdAndRemoveItFromCache() {
         // Given
-        `when`(linkItemRepository.findAllIds()).thenReturn(emptyList())
+        whenever(linkItemRepository.findAllIds()).thenReturn(emptyList())
 
         // When
         val id = randomIdGeneratorService.getGeneratedFreeIdWithCache()
@@ -149,7 +155,7 @@ class RandomIdGeneratorServiceImplTest {
     @Test
     fun getGeneratedFreeIdWithCacheShouldRefillCacheWhenBelowThreshold() {
         // Given — cache is empty, the repository has no existing ids
-        `when`(linkItemRepository.findAllIds()).thenReturn(emptyList())
+        whenever(linkItemRepository.findAllIds()).thenReturn(emptyList())
 
         // When
         randomIdGeneratorService.getGeneratedFreeIdWithCache()
@@ -177,7 +183,7 @@ class RandomIdGeneratorServiceImplTest {
     fun getGeneratedFreeIdWithCacheShouldExcludeExistingRepositoryIds() {
         // Given — cache is empty (below threshold), repository reports some ids as already taken
         val existingId = randomIdGeneratorService.generateRandomId()
-        `when`(linkItemRepository.findAllIds()).thenReturn(listOf(existingId))
+        whenever(linkItemRepository.findAllIds()).thenReturn(listOf(existingId))
 
         // When — cache refill is triggered, existing ids must be filtered out
         val id = randomIdGeneratorService.getGeneratedFreeIdWithCache()


### PR DESCRIPTION

**Title**: MLS-54 — Update Spring Boot lifecycle annotations with more modern solutions

**Summary**
Remplacement des annotations `@PostConstruct` / `@PreDestroy` par les solutions modernes Spring Boot 3+.
`ApplicationReadyEventHandlerForDev` utilise désormais `@EventListener(ApplicationReadyEvent::class)`.
`RandomIdGeneratorServiceImpl` migré de field injection à constructor injection, éliminant les warnings Kotlin KT-73255.

**Changes**
- `ApplicationReadyEventHandlerForDev.kt` — `@param:Value` pour corriger le warning KT-73255 sur le paramètre constructeur
- `RandomIdGeneratorServiceImpl.kt` — field injection → constructor injection avec `@param:Value` (6 propriétés `@Value`)
- `ApplicationReadyEventHandlerForDevTest.kt` — migré vers `mockito-kotlin`, structure Given-When-Then
- `RandomIdGeneratorServiceImplTest.kt` — `Mockito.`when`` → `whenever`, `anyString()` → `anyOrNull()`

**Acceptance Criteria Met**
- [x] Aucune occurrence de `@PostConstruct` dans les sources Kotlin
- [x] Aucune occurrence de `@PreDestroy` dans les sources Kotlin
- [x] Alternatives modernes correctement implémentées
- [x] Tous les tests passent
- [x] Tests mis à jour pour refléter les nouveaux patterns
